### PR TITLE
Fix onchain logic

### DIFF
--- a/src/Bounty.hs
+++ b/src/Bounty.hs
@@ -13,11 +13,12 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 --}
-
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude     #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -25,300 +26,287 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 
 module Bounty where
 
-import           Prelude                (String, show, Show)
-import           Control.Monad          hiding (fmap)
-import           PlutusTx.Maybe
-import qualified Data.Map               as Map
-import           Data.Text              (Text)
-import           Data.Void              (Void)
-import           Plutus.Contract        as Contract
+import           Control.Monad        hiding (fmap)
+import           Data.Aeson           (FromJSON, ToJSON)
+import           Data.List            (intersect, union)
+import qualified Data.Map             as Map
+import           Data.String          (IsString (..))
+import           Data.Text            (Text)
+import           Data.Void            (Void)
+import           GHC.Generics         (Generic)
+import           Ledger               hiding (singleton)
+import           Ledger.Ada           as Ada
+import           Ledger.Constraints   as Constraints
+import qualified Ledger.Contexts      as Validation
+import           Ledger.Credential
+import           Ledger.Index         as Index
+import qualified Ledger.Typed.Scripts as Scripts
+import           Ledger.Value         as Value
+import           Playground.Contract  (NonEmpty (..), ToSchema,
+                                       ensureKnownCurrencies, printJson,
+                                       printSchemas, stage)
+import           Playground.TH        (ensureKnownCurrencies, mkKnownCurrencies,
+                                       mkSchemaDefinitions)
+import           Playground.Types     (KnownCurrency (..))
+import           Plutus.Contract      as Contract
 import qualified PlutusTx
 import           PlutusTx.IsData
-import           PlutusTx.Prelude       hiding (Semigroup(..), unless)
-import           Ledger                 hiding (singleton)
-import           Ledger.Credential
-import           Ledger.Ada             as Ada
-import           Ledger.Constraints     as Constraints
-import           Ledger.Index           as Index
-import qualified Ledger.Typed.Scripts   as Scripts
-import qualified Ledger.Contexts                   as Validation
-import           Ledger.Value           as Value
-import           Playground.Contract    (printJson, printSchemas, ensureKnownCurrencies, stage, ToSchema, NonEmpty(..) )
-import           Playground.TH          (mkKnownCurrencies, mkSchemaDefinitions, ensureKnownCurrencies)
-import           Playground.Types       (KnownCurrency (..))
-import           Prelude                (Semigroup (..))
-import           Text.Printf            (printf)
-import           GHC.Generics         (Generic)
-import           Data.String          (IsString (..))
-import           Data.Aeson           (ToJSON, FromJSON)
-import           Data.List              (union, intersect)
+import           PlutusTx.Maybe
+import           PlutusTx.Prelude     hiding (Semigroup (..), unless)
+import           Prelude              (Semigroup (..), Show, String, show)
+import           Text.Printf          (printf)
 
 data Bounty = Bounty
-    { expiration           :: !POSIXTime
-    , voters               :: ![PubKeyHash]
-    , requiredVotes        :: !Integer
-    , collectionMakerClass :: !AssetClass
-    , collectionToken :: !AssetClass
-    } deriving (Show, Generic, FromJSON, ToJSON)
+  { expiration           :: !POSIXTime,
+    voters               :: ![PubKeyHash],
+    requiredVotes        :: !Integer,
+    collectionMakerClass :: !AssetClass,
+    collectionToken      :: !AssetClass
+  }
+  deriving (Show, Generic, FromJSON, ToJSON)
 
-PlutusTx.makeIsDataIndexed ''Bounty [ ('Bounty, 0) ]
+PlutusTx.makeIsDataIndexed ''Bounty [('Bounty, 0)]
 PlutusTx.makeLift ''Bounty
 
 data Destination = Person PubKeyHash | ScriptH ValidatorHash
-    deriving (Show, Generic, FromJSON, ToJSON)
+  deriving (Show, Generic, FromJSON, ToJSON)
 
-PlutusTx.makeIsDataIndexed ''Destination [ ('Person,  0)
-                                         , ('ScriptH, 1)
-                                         ]
+PlutusTx.makeIsDataIndexed
+  ''Destination
+  [ ('Person, 0),
+    ('ScriptH, 1)
+  ]
 PlutusTx.makeLift ''Destination
 
 data Collection = Collection
-    { votes       :: ![PubKeyHash]
-    , destination :: !Destination
-    } deriving (Show, Generic, FromJSON, ToJSON)
+  { votes       :: ![PubKeyHash],
+    destination :: !Destination
+  }
+  deriving (Show, Generic, FromJSON, ToJSON)
 
-PlutusTx.makeIsDataIndexed ''Collection [ ('Collection, 0) ]
+PlutusTx.makeIsDataIndexed ''Collection [('Collection, 0)]
 PlutusTx.makeLift ''Collection
 
 data BountyDatum = CollectionMaker | CollectionDatum Collection | PotDatum
-    deriving (Show, Generic, FromJSON, ToJSON)
+  deriving (Show, Generic, FromJSON, ToJSON)
 
-PlutusTx.makeIsDataIndexed ''BountyDatum [ ('CollectionMaker, 0)
-                                         , ('CollectionDatum, 1)
-                                         , ('PotDatum,        2)
-                                         ]
+PlutusTx.makeIsDataIndexed
+  ''BountyDatum
+  [ ('CollectionMaker, 0),
+    ('CollectionDatum, 1),
+    ('PotDatum, 2)
+  ]
 PlutusTx.makeLift ''BountyDatum
 
-data BountyAction = ApplyVote | CreateCollection Collection | SpendAction -- | Return -- TODO we need to make this endpoint a reality as well.
-    deriving (Show, Generic, FromJSON, ToJSON)
+-- | Return -- TODO we need to make this endpoint a reality as well.
+data BountyAction = ApplyVote | CreateCollection Collection | SpendAction
+  deriving (Show, Generic, FromJSON, ToJSON)
 
-PlutusTx.makeIsDataIndexed ''BountyAction [ ('ApplyVote,        0)
-                                          , ('CreateCollection, 1)
-                                          , ('SpendAction,      2)
-                                          ]
+PlutusTx.makeIsDataIndexed
+  ''BountyAction
+  [ ('ApplyVote, 0),
+    ('CreateCollection, 1),
+    ('SpendAction, 2)
+  ]
 PlutusTx.makeLift ''BountyAction
 
 data Bountying
+
 instance Scripts.ValidatorTypes Bountying where
-    type instance RedeemerType Bountying = BountyAction
-    type instance DatumType Bountying = BountyDatum
+  type RedeemerType Bountying = BountyAction
+  type DatumType Bountying = BountyDatum
 
 -- Datum Related Functions:
 
-{-# INLINABLE collectionDatum #-}
-collectionDatum :: TxInfo -> TxOut -> Maybe BountyDatum
-collectionDatum txInfo o = do
-    dh      <- txOutDatum o
-    Datum d <- findDatum dh txInfo
-    PlutusTx.fromBuiltinData d
-
-{-# INLINABLE collectionMaker #-}
-collectionMaker :: TxInfo -> TxOut -> Maybe BountyDatum
-collectionMaker txInfo o = do
-    dh      <- txOutDatum o
-    Datum d <- findDatum dh txInfo
-    PlutusTx.fromBuiltinData d
-
-{-# INLINABLE potDatum #-}
-potDatum :: TxInfo -> TxOut -> Maybe BountyDatum
-potDatum txInfo o = do
-    dh      <- txOutDatum o
-    Datum d <- findDatum dh txInfo
-    PlutusTx.fromBuiltinData d
-
+{-# INLINEABLE getBountyDatum #-}
+getBountyDatum :: TxInfo -> TxOut -> Maybe BountyDatum
+getBountyDatum txInfo o = do
+  dh <- txOutDatum o
+  Datum d <- findDatum dh txInfo
+  PlutusTx.fromBuiltinData d
 
 -- Asset Related Functions
-{-# INLINABLE collectionMinted #-}
+{-# INLINEABLE collectionMinted #-}
 collectionMinted :: ScriptContext -> AssetClass -> Integer
 collectionMinted ctx collectionAsset =
-  let
-    mintVal = txInfoMint $ scriptContextTxInfo ctx
-  in
-    assetClassValueOf mintVal collectionAsset
+  let mintVal = txInfoMint $ scriptContextTxInfo ctx
+   in assetClassValueOf mintVal collectionAsset
 
-{-# INLINABLE assetContinues #-}
+{-# INLINEABLE assetContinues #-}
 assetContinues :: ScriptContext -> [TxOut] -> AssetClass -> Bool
 assetContinues ctx continuingOutputs asset =
-    sum [assetClassValueOf (txOutValue x) asset | x <- continuingOutputs] > 0
+  sum [assetClassValueOf (txOutValue x) asset | x <- continuingOutputs] > 0
 
 -- Voting Arithmetic Functions
-{-# INLINABLE validateCollectionChange #-}
+{-# INLINEABLE validateCollectionChange #-}
 validateCollectionChange :: TxInfo -> [PubKeyHash] -> BountyDatum -> Maybe BountyDatum -> Bool
 validateCollectionChange info voters before mafter = case mafter of
   Just (CollectionDatum c) -> case before of
     CollectionDatum k -> validateKeyChanges info voters (votes k) (votes c)
     _                 -> False
-  _                        -> False
+  _ -> False
 
 -- This need to reflect false when we don't have enough votes or if the votes are incorrect.
-{-# INLINABLE solidCollection #-}
+{-# INLINEABLE solidCollection #-}
 solidCollection :: Bounty -> Collection -> Bool
 solidCollection b c =
   let enoughVotes = (requiredVotes b) <= (length (votes c))
       correctVotes = [a | a <- (votes c), elem a (voters b)] -- filterVotes (voters b) (votes c)
-  in
-      length correctVotes == length (votes c) &&
-      enoughVotes
+   in length correctVotes == length (votes c)
+        && enoughVotes
 
-{-# INLINABLE correctCollection #-}
+{-# INLINEABLE correctCollection #-}
 correctCollection :: TxOut -> Collection -> Bool
 correctCollection o c = case (destination c) of
   Person pkh -> case (addressCredential (txOutAddress o)) of
     PubKeyCredential opkh -> pkh == opkh
     _                     -> False
   ScriptH vh -> case (addressCredential (txOutAddress o)) of
-    ScriptCredential ovh  -> vh == ovh
-    _                     -> False
+    ScriptCredential ovh -> vh == ovh
+    _                    -> False
 
 -- We need to make sure that the spending path is correct for the PotDatum TxOut TODO
-{-# INLINABLE validateUseOfPot #-}
+{-# INLINEABLE validateUseOfPot #-}
 validateUseOfPot :: Bounty -> TxOut -> Maybe BountyDatum -> Maybe BountyDatum -> Bool
 validateUseOfPot bounty potTxOut mpot mcollection = case mpot of
   Just m -> case mcollection of
     Just (CollectionDatum c) ->
-      solidCollection bounty c &&
-      correctCollection potTxOut c
-    _                        -> False
-  _      -> False
+      solidCollection bounty c
+        && correctCollection potTxOut c
+    _ -> False
+  _ -> False
 
 -- This needs to check that
 -- - Only valid voters are counted
 -- - All new voters have signed the tx.
-{-# INLINABLE validateKeyChanges #-}
+{-# INLINEABLE validateKeyChanges #-}
 validateKeyChanges :: TxInfo -> [PubKeyHash] -> [PubKeyHash] -> [PubKeyHash] -> Bool
 validateKeyChanges info voters before after =
   let newVotes = [a | a <- after, elem a voters]
       compVal = [a | a <- after, elem a before]
-  in
-    compVal == before &&
-    all (txSignedBy info) newVotes
+   in compVal == before
+        && all (txSignedBy info) newVotes
 
 -- High-Level Functions -- ehh lmao
-{-# INLINABLE containsClass #-}
+{-# INLINEABLE containsClass #-}
 containsClass :: TxOut -> AssetClass -> Bool
 containsClass o a = (assetClassValueOf (txOutValue o) a) > 0
 
-{-# INLINABLE getOutput #-}
+{-# INLINEABLE getOutput #-}
 getOutput :: [TxOut] -> AssetClass -> TxOut
 getOutput txOuts asset = case [o | o <- txOuts, containsClass o asset] of
-    [x] -> x
-    _   -> traceError "Fail here."
+  [x] -> x
+  _   -> traceError "Fail here."
 
-{-# INLINABLE containsPot #-}
+{-# INLINEABLE containsPot #-}
 containsPot :: TxInfo -> TxOut -> Bool
 containsPot info o =
-  let d = potDatum info o
-  in case d of
-    Just PotDatum -> True
-    _             -> False
+  let d = getBountyDatum info o
+   in case d of
+        Just PotDatum -> True
+        _             -> False
 
-{-# INLINABLE getOutputPDatum #-}
+{-# INLINEABLE getOutputPDatum #-}
 getOutputPDatum :: TxInfo -> [TxOut] -> TxOut
 getOutputPDatum info txOuts = case [o | o <- txOuts, containsPot info o] of
-    [x] -> x
-    _   -> traceError "Fail here."
+  [x] -> x
+  _   -> traceError "Fail here."
 
-{-# INLINABLE startCollectionDatum #-}
+{-# INLINEABLE startCollectionDatum #-}
 startCollectionDatum :: Maybe BountyDatum -> Bool
 startCollectionDatum md = case md of
   Just (CollectionDatum c) ->
     length (votes c) == 0
-  _                        -> False
+  _ -> False
 
-{-# INLINABLE validMakerDatum #-}
+{-# INLINEABLE validMakerDatum #-}
 validMakerDatum :: Maybe BountyDatum -> Bool
 validMakerDatum md = case md of
   Just CollectionMaker ->
     True
-  _                        -> False
+  _ -> False
 
-{-# INLINABLE validPotDatum #-}
+{-# INLINEABLE validPotDatum #-}
 validPotDatum :: Maybe BountyDatum -> Bool
 validPotDatum md = case md of
   Just PotDatum ->
     True
-  _                        -> False
+  _ -> False
 
 -- - Collection maker class come and go
 -- - CollectionDatum value starts with an empty voter list.
--- - 
-{-# INLINABLE checkCreateCollection #-}
+-- -
+{-# INLINEABLE checkCreateCollection #-}
 checkCreateCollection :: ScriptContext -> BountyDatum -> AssetClass -> AssetClass -> Bool
 checkCreateCollection ctx collection makerAsset collectionAsset =
-  let
-    txInfo = scriptContextTxInfo ctx
-    outputs = txInfoOutputs txInfo
-    continuingOutputs = getContinuingOutputs ctx
-    datumMaker = collectionMaker txInfo (getOutput outputs makerAsset)
-    datumBox = collectionDatum txInfo (getOutput outputs collectionAsset)
-  in
-    assetContinues ctx continuingOutputs makerAsset &&
-    assetContinues ctx continuingOutputs collectionAsset &&
-    (collectionMinted ctx collectionAsset) == 1 &&
-    startCollectionDatum datumBox &&
-    validMakerDatum datumMaker
+  let txInfo = scriptContextTxInfo ctx
+      outputs = txInfoOutputs txInfo
+      continuingOutputs = getContinuingOutputs ctx
+      datumMaker = getBountyDatum txInfo (getOutput outputs makerAsset)
+      datumBox = getBountyDatum txInfo (getOutput outputs collectionAsset)
+   in assetContinues ctx continuingOutputs makerAsset
+        && assetContinues ctx continuingOutputs collectionAsset
+        && (collectionMinted ctx collectionAsset) == 1
+        && startCollectionDatum datumBox
+        && validMakerDatum datumMaker
 
 -- - For each pubkeyhash being added to the application must have signed.
 -- - None of the pubkeyhashes added can be the same as eachother or the values in the list.
-{-# INLINABLE checkVoteApplication #-}
+{-# INLINEABLE checkVoteApplication #-}
 checkVoteApplication :: ScriptContext -> AssetClass -> BountyDatum -> [PubKeyHash] -> Bool
 checkVoteApplication ctx collectionAsset datum voters =
-  let
-    txInfo = scriptContextTxInfo ctx
-    outputs = txInfoOutputs txInfo
-    continuingOutputs = getContinuingOutputs ctx
-    datumBox = collectionDatum txInfo (getOutput outputs collectionAsset)
-  in
-    assetContinues ctx continuingOutputs collectionAsset &&
-    validateCollectionChange txInfo voters datum datumBox
+  let txInfo = scriptContextTxInfo ctx
+      outputs = txInfoOutputs txInfo
+      continuingOutputs = getContinuingOutputs ctx
+      datumBox = getBountyDatum txInfo (getOutput outputs collectionAsset)
+   in assetContinues ctx continuingOutputs collectionAsset
+        && validateCollectionChange txInfo voters datum datumBox
 
--- - Are there enough voters in the list 
+-- - Are there enough voters in the list
 -- - There's only one collectionAsset present as input and it is attached to a valid datum value for usage.
--- - The value attached to the PotDatum is sent to the 
-{-# INLINABLE checkSpending #-}
+-- - The value attached to the PotDatum is sent to the
+{-# INLINEABLE checkSpending #-}
 checkSpending :: ScriptContext -> Bounty -> Bool
 checkSpending ctx bounty =
-  let
-    txInfo = scriptContextTxInfo ctx
-    txIns = txInfoInputs txInfo
-    outputs = txInfoOutputs txInfo
-    continuingOutputs = getContinuingOutputs ctx
-    datumBox = collectionDatum txInfo (getOutput outputs (collectionToken bounty))
-    potTxOut = getOutputPDatum txInfo outputs
-    potBox = potDatum txInfo potTxOut
-    txInValues = [txOutValue $ txInInfoResolved txIn | txIn <- txIns]
-  in
-    validateUseOfPot bounty potTxOut potBox datumBox
+  let txInfo = scriptContextTxInfo ctx
+      txIns = txInfoInputs txInfo
+      outputs = txInfoOutputs txInfo
+      continuingOutputs = getContinuingOutputs ctx
+      datumBox = getBountyDatum txInfo (getOutput outputs (collectionToken bounty))
+      potTxOut = getOutputPDatum txInfo outputs
+      potBox = getBountyDatum txInfo potTxOut
+      txInValues = [txOutValue $ txInInfoResolved txIn | txIn <- txIns]
+   in validateUseOfPot bounty potTxOut potBox datumBox
 
 -- We only can have one CollectionDatum/Token - We need to implement these - definitely.
--- We only can have one 
+-- We only can have one
 
-{-# INLINABLE bountyScript #-}
+{-# INLINEABLE bountyScript #-}
 bountyScript :: Bounty -> BountyDatum -> BountyAction -> ScriptContext -> Bool
 bountyScript bounty datum action ctx = case datum of
-    CollectionMaker   -> case action of
-        CreateCollection c -> checkCreateCollection ctx datum (collectionMakerClass bounty) (collectionToken bounty)
-        _                  -> False
-    CollectionDatum c -> case action of
-        ApplyVote          -> checkVoteApplication ctx (collectionMakerClass bounty) datum (voters bounty)
-        SpendAction        -> checkSpending ctx bounty
-        _                  -> False
-    PotDatum          -> case action of
-        SpendAction        -> checkSpending ctx bounty
-        _                  -> False
+  CollectionMaker -> case action of
+    CreateCollection c -> checkCreateCollection ctx datum (collectionMakerClass bounty) (collectionToken bounty)
+    _ -> False
+  CollectionDatum c -> case action of
+    ApplyVote -> checkVoteApplication ctx (collectionMakerClass bounty) datum (voters bounty)
+    SpendAction -> checkSpending ctx bounty
+    _ -> False
+  PotDatum -> case action of
+    SpendAction -> checkSpending ctx bounty
+    _           -> False
 
 bountyValidatorInstance :: Bounty -> Scripts.TypedValidator Bountying
-bountyValidatorInstance bounty = Scripts.mkTypedValidator @Bountying
-    ($$(PlutusTx.compile [|| bountyScript ||])
-    `PlutusTx.applyCode`
-    PlutusTx.liftCode bounty)
-    $$(PlutusTx.compile [|| wrap ||]) where
-        wrap = Scripts.wrapValidator @BountyDatum @BountyAction
+bountyValidatorInstance bounty =
+  Scripts.mkTypedValidator @Bountying
+    ( $$(PlutusTx.compile [||bountyScript||])
+        `PlutusTx.applyCode` PlutusTx.liftCode bounty
+    )
+    $$(PlutusTx.compile [||wrap||])
+  where
+    wrap = Scripts.wrapValidator @BountyDatum @BountyAction
 
 bountyValidatorHash :: Bounty -> ValidatorHash
 bountyValidatorHash bounty = Scripts.validatorHash (bountyValidatorInstance bounty)

--- a/src/Bounty.hs
+++ b/src/Bounty.hs
@@ -121,27 +121,27 @@ instance Scripts.ValidatorTypes Bountying where
 
 -- Datum Related Functions:
 
-{-# INLINEABLE getBountyDatum #-}
+{-# INLINABLE getBountyDatum #-}
 getBountyDatum :: TxInfo -> TxOut -> Maybe BountyDatum
 getBountyDatum txInfo o = do
-  dh <- txOutDatum o
-  Datum d <- findDatum dh txInfo
+  datumHash <- txOutDatum o
+  Datum d <- findDatum datumHash txInfo
   PlutusTx.fromBuiltinData d
 
 -- Asset Related Functions
-{-# INLINEABLE collectionMinted #-}
+{-# INLINABLE collectionMinted #-}
 collectionMinted :: ScriptContext -> AssetClass -> Integer
 collectionMinted ctx collectionAsset =
   let mintVal = txInfoMint $ scriptContextTxInfo ctx
    in assetClassValueOf mintVal collectionAsset
 
-{-# INLINEABLE assetContinues #-}
+{-# INLINABLE assetContinues #-}
 assetContinues :: ScriptContext -> [TxOut] -> AssetClass -> Bool
 assetContinues ctx continuingOutputs asset =
   sum [assetClassValueOf (txOutValue x) asset | x <- continuingOutputs] > 0
 
 -- Voting Arithmetic Functions
-{-# INLINEABLE validateCollectionChange #-}
+{-# INLINABLE validateCollectionChange #-}
 validateCollectionChange :: TxInfo -> [PubKeyHash] -> BountyDatum -> Maybe BountyDatum -> Bool
 validateCollectionChange info voters before mafter = case mafter of
   Just (CollectionDatum c) -> case before of
@@ -150,7 +150,7 @@ validateCollectionChange info voters before mafter = case mafter of
   _ -> False
 
 -- This need to reflect false when we don't have enough votes or if the votes are incorrect.
-{-# INLINEABLE solidCollection #-}
+{-# INLINABLE solidCollection #-}
 solidCollection :: Bounty -> Collection -> Bool
 solidCollection b c =
   let enoughVotes = (requiredVotes b) <= (length (votes c))
@@ -158,7 +158,7 @@ solidCollection b c =
    in length correctVotes == length (votes c)
         && enoughVotes
 
-{-# INLINEABLE correctCollection #-}
+{-# INLINABLE correctCollection #-}
 correctCollection :: TxOut -> Collection -> Bool
 correctCollection o c = case (destination c) of
   Person pkh -> case (addressCredential (txOutAddress o)) of
@@ -169,20 +169,17 @@ correctCollection o c = case (destination c) of
     _                    -> False
 
 -- We need to make sure that the spending path is correct for the PotDatum TxOut TODO
-{-# INLINEABLE validateUseOfPot #-}
-validateUseOfPot :: Bounty -> TxOut -> Maybe BountyDatum -> Maybe BountyDatum -> Bool
-validateUseOfPot bounty potTxOut mpot mcollection = case mpot of
-  Just m -> case mcollection of
-    Just (CollectionDatum c) ->
-      solidCollection bounty c
-        && correctCollection potTxOut c
-    _ -> False
-  _ -> False
+{-# INLINABLE validateUseOfPot #-}
+validateUseOfPot :: Bounty -> Maybe TxOut -> Maybe BountyDatum -> Maybe BountyDatum -> Bool
+-- validateUseOfPot bounty mPotTxOut mpot mcollection = case mpot of
+validateUseOfPot bounty (Just potTxOut) (Just _) (Just (CollectionDatum c)) =
+  solidCollection bounty c && correctCollection potTxOut c
+validateUseOfPot _ _ _ _ = False
 
 -- This needs to check that
 -- - Only valid voters are counted
 -- - All new voters have signed the tx.
-{-# INLINEABLE validateKeyChanges #-}
+{-# INLINABLE validateKeyChanges #-}
 validateKeyChanges :: TxInfo -> [PubKeyHash] -> [PubKeyHash] -> [PubKeyHash] -> Bool
 validateKeyChanges info voters before after =
   let newVotes = [a | a <- after, elem a voters]
@@ -191,62 +188,54 @@ validateKeyChanges info voters before after =
         && all (txSignedBy info) newVotes
 
 -- High-Level Functions -- ehh lmao
-{-# INLINEABLE containsClass #-}
+{-# INLINABLE containsClass #-}
 containsClass :: TxOut -> AssetClass -> Bool
 containsClass o a = (assetClassValueOf (txOutValue o) a) > 0
 
-{-# INLINEABLE getOutput #-}
-getOutput :: [TxOut] -> AssetClass -> TxOut
-getOutput txOuts asset = case [o | o <- txOuts, containsClass o asset] of
-  [x] -> x
-  _   -> traceError "Fail here."
+{-# INLINABLE findOutputForClass #-}
+findOutputForClass :: AssetClass -> [TxOut] -> Maybe TxOut
+findOutputForClass asset = find $ \o -> containsClass o asset
 
-{-# INLINEABLE containsPot #-}
+{-# INLINABLE containsPot #-}
 containsPot :: TxInfo -> TxOut -> Bool
 containsPot info o =
-  let d = getBountyDatum info o
-   in case d of
-        Just PotDatum -> True
-        _             -> False
+  case getBountyDatum info o of
+    Just PotDatum -> True
+    _             -> False
 
-{-# INLINEABLE getOutputPDatum #-}
-getOutputPDatum :: TxInfo -> [TxOut] -> TxOut
-getOutputPDatum info txOuts = case [o | o <- txOuts, containsPot info o] of
-  [x] -> x
-  _   -> traceError "Fail here."
+{-# INLINABLE getOutputPDatum #-}
+getOutputPDatum :: TxInfo -> [TxOut] -> Maybe TxOut
+getOutputPDatum info txOuts = find (containsPot info) txOuts
 
-{-# INLINEABLE startCollectionDatum #-}
+{-# INLINABLE startCollectionDatum #-}
 startCollectionDatum :: Maybe BountyDatum -> Bool
 startCollectionDatum md = case md of
-  Just (CollectionDatum c) ->
-    length (votes c) == 0
-  _ -> False
+  Just (CollectionDatum c) -> length (votes c) == 0
+  _                        -> False
 
-{-# INLINEABLE validMakerDatum #-}
+{-# INLINABLE validMakerDatum #-}
 validMakerDatum :: Maybe BountyDatum -> Bool
 validMakerDatum md = case md of
-  Just CollectionMaker ->
-    True
-  _ -> False
+  Just CollectionMaker -> True
+  _                    -> False
 
-{-# INLINEABLE validPotDatum #-}
+{-# INLINABLE validPotDatum #-}
 validPotDatum :: Maybe BountyDatum -> Bool
 validPotDatum md = case md of
-  Just PotDatum ->
-    True
-  _ -> False
+  Just PotDatum -> True
+  _             -> False
 
 -- - Collection maker class come and go
 -- - CollectionDatum value starts with an empty voter list.
 -- -
-{-# INLINEABLE checkCreateCollection #-}
+{-# INLINABLE checkCreateCollection #-}
 checkCreateCollection :: ScriptContext -> BountyDatum -> AssetClass -> AssetClass -> Bool
 checkCreateCollection ctx collection makerAsset collectionAsset =
   let txInfo = scriptContextTxInfo ctx
       outputs = txInfoOutputs txInfo
       continuingOutputs = getContinuingOutputs ctx
-      datumMaker = getBountyDatum txInfo (getOutput outputs makerAsset)
-      datumBox = getBountyDatum txInfo (getOutput outputs collectionAsset)
+      datumMaker = findOutputForClass makerAsset outputs >>= getBountyDatum txInfo
+      datumBox = findOutputForClass collectionAsset outputs >>= getBountyDatum txInfo
    in assetContinues ctx continuingOutputs makerAsset
         && assetContinues ctx continuingOutputs collectionAsset
         && (collectionMinted ctx collectionAsset) == 1
@@ -255,36 +244,36 @@ checkCreateCollection ctx collection makerAsset collectionAsset =
 
 -- - For each pubkeyhash being added to the application must have signed.
 -- - None of the pubkeyhashes added can be the same as eachother or the values in the list.
-{-# INLINEABLE checkVoteApplication #-}
+{-# INLINABLE checkVoteApplication #-}
 checkVoteApplication :: ScriptContext -> AssetClass -> BountyDatum -> [PubKeyHash] -> Bool
 checkVoteApplication ctx collectionAsset datum voters =
   let txInfo = scriptContextTxInfo ctx
       outputs = txInfoOutputs txInfo
       continuingOutputs = getContinuingOutputs ctx
-      datumBox = getBountyDatum txInfo (getOutput outputs collectionAsset)
+      datumBox = findOutputForClass collectionAsset outputs >>= getBountyDatum txInfo
    in assetContinues ctx continuingOutputs collectionAsset
         && validateCollectionChange txInfo voters datum datumBox
 
 -- - Are there enough voters in the list
 -- - There's only one collectionAsset present as input and it is attached to a valid datum value for usage.
 -- - The value attached to the PotDatum is sent to the
-{-# INLINEABLE checkSpending #-}
+{-# INLINABLE checkSpending #-}
 checkSpending :: ScriptContext -> Bounty -> Bool
 checkSpending ctx bounty =
   let txInfo = scriptContextTxInfo ctx
       txIns = txInfoInputs txInfo
       outputs = txInfoOutputs txInfo
       continuingOutputs = getContinuingOutputs ctx
-      datumBox = getBountyDatum txInfo (getOutput outputs (collectionToken bounty))
+      datumBox = findOutputForClass (collectionToken bounty) outputs >>= getBountyDatum txInfo
       potTxOut = getOutputPDatum txInfo outputs
-      potBox = getBountyDatum txInfo potTxOut
+      potBox = potTxOut >>= getBountyDatum txInfo
       txInValues = [txOutValue $ txInInfoResolved txIn | txIn <- txIns]
    in validateUseOfPot bounty potTxOut potBox datumBox
 
 -- We only can have one CollectionDatum/Token - We need to implement these - definitely.
 -- We only can have one
 
-{-# INLINEABLE bountyScript #-}
+{-# INLINABLE bountyScript #-}
 bountyScript :: Bounty -> BountyDatum -> BountyAction -> ScriptContext -> Bool
 bountyScript bounty datum action ctx = case datum of
   CollectionMaker -> case action of

--- a/src/CollectionMaker.hs
+++ b/src/CollectionMaker.hs
@@ -18,6 +18,7 @@
 {-# LANGUAGE DeriveAnyClass      #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -25,35 +26,14 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE LambdaCase          #-}
 
 module CollectionMaker where
 
-import           Prelude                (String, show, Show)
-import           Control.Monad          hiding (fmap)
-import           PlutusTx.Maybe
-import qualified Data.Map               as Map
-import           Data.Text              (Text)
-import           Data.Void              (Void)
-import           Plutus.Contract        as Contract
+import           Ledger               hiding (singleton)
+import qualified Ledger.Typed.Scripts as Scripts
+import           Ledger.Value         as Value
 import qualified PlutusTx
-import           PlutusTx.IsData
-import           PlutusTx.Prelude       hiding (Semigroup(..), unless)
-import           Ledger                 hiding (singleton)
-import           Ledger.Ada             as Ada
-import           Ledger.Constraints     as Constraints
-import           Ledger.Index           as Index
-import qualified Ledger.Typed.Scripts   as Scripts
-import qualified Ledger.Contexts                   as Validation
-import           Ledger.Value           as Value
-import           Playground.Contract    (printJson, printSchemas, ensureKnownCurrencies, stage, ToSchema, NonEmpty(..) )
-import           Playground.TH          (mkKnownCurrencies, mkSchemaDefinitions, ensureKnownCurrencies)
-import           Playground.Types       (KnownCurrency (..))
-import           Prelude                (Semigroup (..))
-import           Text.Printf            (printf)
-import           GHC.Generics         (Generic)
-import           Data.String          (IsString (..))
-import           Data.Aeson           (ToJSON, FromJSON)
+import           PlutusTx.Prelude     hiding (Semigroup (..), unless)
 
 {-# INLINABLE mkPolicy #-}
 mkPolicy :: AssetClass -> BuiltinData -> ScriptContext -> Bool
@@ -63,12 +43,11 @@ mkPolicy asset _ ctx =
   where
     txInfo = scriptContextTxInfo ctx
     txInValues = [txOutValue $ txInInfoResolved txIn | txIn <- txInfoInputs $ scriptContextTxInfo ctx]
-    txOuts = txInfoOutputs txInfo
     nftValues = [assetClassValueOf val asset | val <- txInValues]
     nftSum = sum nftValues
     mintedAmount = case flattenValue (txInfoMint txInfo) of
-          [(cs, collectionTokenName, amt)] | cs == ownCurrencySymbol ctx -> amt
-          _                                                              -> 0
+          [(cs, _, amt)] | cs == ownCurrencySymbol ctx -> amt
+          _                                            -> 0
 
 policy :: AssetClass -> Scripts.MintingPolicy
 policy asset = mkMintingPolicyScript $


### PR DESCRIPTION
Fix logic where it bails (though `traceError `) due to invalid input. If invalid input's received, the validator should always validate to `False` instead of bailing with error. Also `trace` calls aren't supposed to be used in production environment. They are only for testing purpose. 

There's also format changes that's a result of [stylish-haskell](https://github.com/haskell/stylish-haskell). Please let me know if you are happy with the formatter, I can revert the format changes. That said, I see this as overall an improvement to the format.